### PR TITLE
Improve program sensor

### DIFF
--- a/custom_components/vzug/sensor.py
+++ b/custom_components/vzug/sensor.py
@@ -124,9 +124,12 @@ class Program(StateBase):
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         device = self.coordinator.data.device
-        if device.get("Inactive") == "true":
+        if device.get("Program"):
+            return device.get("Program")
+        elif device.get("Inactive") == "true":
             return "standby"
-        return device.get("Program")
+        else:
+            return "active"
 
 
 class ProgramEndRaw(StateBase):

--- a/custom_components/vzug/sensor.py
+++ b/custom_components/vzug/sensor.py
@@ -124,8 +124,8 @@ class Program(StateBase):
     @property
     def native_value(self) -> StateType | date | datetime | Decimal:
         device = self.coordinator.data.device
-        if device.get("Program"):
-            return device.get("Program")
+        if program := device.get("Program"):
+            return program
         elif device.get("Inactive") == "true":
             return "standby"
         else:

--- a/custom_components/vzug/translations/de.json
+++ b/custom_components/vzug/translations/de.json
@@ -70,7 +70,8 @@
       "program": {
         "name": "Programm",
         "state": {
-          "standby": "Standby"
+          "standby": "Standby",
+          "active": "Aktiv"
         }
       },
       "program_end": {

--- a/custom_components/vzug/translations/en.json
+++ b/custom_components/vzug/translations/en.json
@@ -70,7 +70,8 @@
             "program": {
                 "name": "Program",
                 "state": {
-                    "standby": "Standby"
+                    "standby": "Standby",
+                    "active": "Active"
                 }
             },
             "program_end": {

--- a/custom_components/vzug/translations/fr.json
+++ b/custom_components/vzug/translations/fr.json
@@ -70,7 +70,8 @@
             "program": {
                 "name": "Programme",
                 "state": {
-                    "standby": "Veille"
+                    "standby": "Veille",
+                    "active": "Actif"
                 }
             },
             "program_end": {


### PR DESCRIPTION
Currently the sensor "program" shows a combination of two device states (Inactive and Program).
This leads to the following issues:
* For devices like the "Cooler V2000", the device value of program is mostly hidden with "standby" as the value "Inactive" is true in normal operation mode.
* For devices like the "Combair-Steamer V2000", the program shows "standby" even if the device is active (Inactive is false), but no specific program is selected.

The PR tries to address both issues:
* If the value of the device field "Program" is set, it has always priority.
* If the value of the device field "Program" is empty, depending on the device field "Inactive" the value "standby" or "active" is reported.