### PR TITLE
Add migration for uid

### DIFF
--- a/custom_components/vzug/__init__.py
+++ b/custom_components/vzug/__init__.py
@@ -3,6 +3,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from yarl import URL
 
 from . import api
@@ -52,18 +53,38 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    _LOGGER.debug("migrating from version %s", config_entry.version)
+    _LOGGER.debug("migrating from version %s.%s", config_entry.version, config_entry.minor_version)
 
     if config_entry.version == 1:
+        # migrate old entity unique id
+        entity_reg = er.async_get(hass)
+        entities: list[er.RegistryEntry] = er.async_entries_for_config_entry(
+            entity_reg, config_entry.entry_id
+        )
+
+        shared: Shared = hass.data[DOMAIN][config_entry.entry_id]
+        old_prefix = shared.state_coord.data.device.get("deviceUuid", "") or shared.state_coord.data.device.get("Serial", "")
+        mac_addr = dr.format_mac(shared.meta.mac_address)
+
+        for entity in entities:
+            #migrate unique_id_prefix from 'device_uuid' or 'device_serial' to 'mac_addr'
+            new_uid = entity.unique_id.replace(old_prefix, mac_addr)
+            _LOGGER.debug(
+                "migrate unique id '%s' to '%s'", entity.unique_id, new_uid
+            )
+            entity_reg.async_update_entity(
+                entity.entity_id, new_unique_id=new_uid
+            )
+
+        # migrate base_url
         base_url = URL(config_entry.data["host"])
         if not base_url.is_absolute():
             base_url = URL(f"http://{base_url}")
 
-        config_entry.version = 2
         hass.config_entries.async_update_entry(
-            config_entry, data={"base_url": str(base_url)}
+            config_entry, data={"base_url": str(base_url)}, version = 2, minor_version = 2
         )
 
-    _LOGGER.info("migration to version %s successful", config_entry.version)
+    _LOGGER.debug("migration to version %s.%s successful", config_entry.version, config_entry.minor_version)
 
     return True

--- a/custom_components/vzug/config_flow.py
+++ b/custom_components/vzug/config_flow.py
@@ -42,6 +42,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for V-ZUG."""
 
     VERSION = 2
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         self._base_url: URL | None = None


### PR DESCRIPTION
Add migration for entity unique_id in order to prevent a breaking change.

For users already updated to ConfigEntry Version 2 no migration is made, as the users with this version might already have deleted the old entities and definitively already have the new entities.