### PR TITLE
Fix deprecation warning for homeassistant.components.dhcp

### DIFF
--- a/custom_components/vzug/config_flow.py
+++ b/custom_components/vzug/config_flow.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components.dhcp import DhcpServiceInfo
 from homeassistant.components.network import Adapter, async_get_adapters
 from homeassistant.const import CONF_BASE, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
@@ -20,6 +19,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from yarl import URL
 
 from . import api


### PR DESCRIPTION
Since HA 2025.3 the import of homeassistant.components.dhcp.DhcpServiceInfo logs a deprecation warning.
Need to be fixed before HA 2026.2.