### PR TITLE
Set PYTHONPATH to avoid 'module not found' issues during debugging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,16 @@
 
     "postCreateCommand": "scripts/setup",
 
-    //Aparently we don't need to manually forward 5678
-    //It is usally detected when launching ./scripts/develop
-    //Declaring manually gives it a name in VScode
+    // Make sure we always use the same root folder, no matter what a fork is called
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/v-zug,type=bind",
+    "workspaceFolder": "/workspaces/v-zug",
+    "remoteEnv": {
+        "PROJECT_ROOT": "/workspaces/v-zug",
+        "PYTHONPATH": "/workspaces/v-zug"
+    },
+
+    // We don't need to manually forward 5678. It is usually detected when launching ./scripts/develop. 
+    // But declaring manually will assign a name in VScode
     "forwardPorts": [
         5678,
         8123
@@ -21,6 +28,7 @@
             "onAutoForward": "openBrowserOnce"
         }
     },
+
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             ]
         },
         {
-            "name": "Python: File",
+            "name": "Python: Current File",
             "type": "debugpy",
             "request": "launch",
             "program": "${file}"


### PR DESCRIPTION
Use the same root inside the dev container and also declare it as two variables
- PYTHONPATH to define the imports
- PROJECT_ROOT to help the scripts and tests