### PR TITLE
Define required version of json-repair

### DIFF
--- a/custom_components/vzug/manifest.json
+++ b/custom_components/vzug/manifest.json
@@ -23,7 +23,7 @@
   "loggers": [],
   "mqtt": [],
   "requirements": [
-    "json-repair==0.46.2"
+    "json-repair~=0.46.2"
   ],
   "ssdp": [],
   "usb": [],

--- a/custom_components/vzug/manifest.json
+++ b/custom_components/vzug/manifest.json
@@ -23,7 +23,7 @@
   "loggers": [],
   "mqtt": [],
   "requirements": [
-    "json-repair"
+    "json-repair==0.46.2"
   ],
   "ssdp": [],
   "usb": [],


### PR DESCRIPTION
This follows the documentation of manifest.json. 

Without the version specified the latest version will be used. Which is fine, but maybe you want to be precise.