### PR TITLE
Fix deprecation warning for DhcpServiceInfo

### DIFF
--- a/custom_components/vzug/config_flow.py
+++ b/custom_components/vzug/config_flow.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components.dhcp import DhcpServiceInfo
 from homeassistant.components.network import Adapter, async_get_adapters
 from homeassistant.const import CONF_BASE, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
@@ -20,6 +19,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from yarl import URL
 
 from . import api

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "V-ZUG",
     "filename": "vzug.zip",
     "hide_default_branch": true,
-    "homeassistant": "2025.5.3",
+    "homeassistant": "2025.6.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coloredlogs==15.0.1
-homeassistant==2025.5.3
+homeassistant==2025.6.0
 ruff==0.11.13
 flask==3.1.1
 isort==6.0.1


### PR DESCRIPTION
Again fixes the deprecation warning as of issue #99.

Why was this change undone in commit https://github.com/siku2/hass-vzug/commit/d374f31b3ab12fd8700fef3cfe097c1b041ea8ee ?

I tested it with the newest HA version and it works well and creates no more deprecation warnings.