### PR TITLE
Fix Adora Wash command URL encoding to prevent 400 Bad Request (#144)

### DIFF
--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -3,6 +3,7 @@ import dataclasses
 import json
 import logging
 import time
+import urllib.parse
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, Literal, TypedDict, cast
@@ -281,11 +282,16 @@ class VZugApi:
     ) -> Any:
         if params is None:
             params = {}
-        final_params = params.copy()
-        final_params["command"] = command
-        final_params["_"] = str(int(time.time()))
+
+        # Some appliances are strict about query formatting. Mirror web UI shape:
+        # command first, value second, cache-buster in milliseconds, and spaces as %20.
+        final_params: dict[str, str] = {"command": command}
+        final_params.update(params)
+        final_params["_"] = str(int(time.time() * 1000))
+        query = urllib.parse.urlencode(final_params, quote_via=urllib.parse.quote)
 
         url = str(self._base_url / component)
+        request_url = f"{url}?{query}"
 
         async def once() -> Any:
             _LOGGER.debug(
@@ -295,7 +301,7 @@ class VZugApi:
                 component,
                 self._base_url,
             )
-            resp = await self._client.get(url, params=final_params)
+            resp = await self._client.get(request_url)
             resp.raise_for_status()
 
             if raw:


### PR DESCRIPTION
## Issue:
The Adora Wash API call for setting warm/cold water options failed with HTTP 400 in Home Assistant, while the same action worked from the device web UI. The integration generated a different query format than the appliance UI:

Spaces in query params were encoded as + instead of %20. Query param order differed from the working UI request. Cache-buster _ used seconds instead of milliseconds. Root cause:
Some V-ZUG hh endpoints are strict about URL/query formatting and rejected the integration-generated request for selection values containing spaces/umlauts.

## Fix:
Updated request construction in __init__.py:

Build query params in UI-compatible order: 
- command, then value, then _. 
- Use explicit URL encoding with urllib.parse.urlencode(..., quote_via=urllib.parse.quote) so spaces become %20. 
- Use millisecond timestamp for _ to match browser behavior. Send the pre-encoded request URL to preserve exact query formatting. 

## Result:
Fixes #144 for me.
The integration now mirrors the appliance web UI request format, resolving 400 errors for commands like setsettingWarmColdWater with localized option values. 

## Important:
Hope it does not break anything else. I am not a Python developer. Changes done with help from copilot after my investigations. Tested then successfully by patching the `__init__.py` file directly in my homeassistant's `custom_components/vzug/api` directory.