### PR TITLE
fix: make _command retry handling robust against transport errors and JSON error bodies

### DIFF
--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -327,6 +327,12 @@ class VZugApi:
                     data = None
 
             _LOGGER.debug("data: %s", data)
+            if isinstance(data, dict) and "error" in data:
+                # some appliances report unsupported commands and transient failures
+                # with a json error body and HTTP 200. Without this the body would
+                # satisfy the type check below and get stored as if it were valid.
+                raise ValueError(f"device returned an error response: {data['error']}")
+
             if expected_type is list and data is None:
                 # if we want a list and the response is null, we just treat that as an empty list
                 data: Any = []
@@ -358,7 +364,6 @@ class VZugApi:
             except httpx.TransportError as err:
                 last_exc = err
                 _LOGGER.debug("transport error: %r", err)
-                continue
             except AssertionError as exc:
                 last_exc = exc
                 _LOGGER.debug("response data assertion failed: %s", exc)
@@ -614,7 +619,7 @@ class VZugApi:
             expected_type=dict,
             value_on_err=(lambda: {"value": -1}) if default_on_error else None,
         )
-        return data["value"]
+        return data.get("value", -1)
 
     async def get_eco_info(self, *, default_on_error: bool = False) -> EcoInfo:
         result = await self._command(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,14 @@
+import httpx
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
-
 from custom_components.vzug.api import VZugApi
+
+def _json_response(payload):
+    """Build a mock httpx response which returns 'payload' from .json()."""
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
 
 
 @pytest.fixture
@@ -118,3 +125,63 @@ async def test_json_repair_with_real_broken_device_status():
 
         assert result is not None
         assert len(result) == 8
+
+@pytest.mark.asyncio
+async def test_transport_error_counts_as_attempt(vzug_api):
+    """A transport error must not restart the loop without incrementing the counter."""
+    with patch.object(vzug_api._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = httpx.ReadTimeout("")
+
+        with pytest.raises(httpx.ReadTimeout):
+            await vzug_api._command(
+                "hh", command="getEcoInfo", attempts=3, retry_delay=0.0
+            )
+
+        # without the fix this loops forever because 'continue' skips 'attempt_idx += 1'
+        assert mock_get.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_json_error_body_is_retried(vzug_api):
+    """A json error body with HTTP 200 must not be accepted as valid data."""
+    with patch.object(vzug_api._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = [
+            _json_response({"error": {"code": 503.01}}),
+            _json_response({"value": 2}),
+        ]
+
+        result = await vzug_api._command(
+            "hh", command="getZHMode", expected_type=dict, retry_delay=0.0
+        )
+
+        assert result == {"value": 2}
+        assert mock_get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_json_error_body_falls_back_to_default(vzug_api):
+    """When every attempt returns an error body, 'value_on_err' has to kick in."""
+    with patch.object(vzug_api._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _json_response({"error": {"code": 404}})
+
+        result = await vzug_api._command(
+            "hh",
+            command="getZHMode",
+            expected_type=dict,
+            attempts=2,
+            retry_delay=0.0,
+            value_on_err=lambda: {"value": -1},
+        )
+
+        assert result == {"value": -1}
+        assert mock_get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_zh_mode_survives_missing_value_key(vzug_api):
+    """An unexpected body must not raise a KeyError outside of the retry path."""
+    with patch.object(vzug_api, "_command", new_callable=AsyncMock) as mock_command:
+        mock_command.return_value = {}
+
+        assert await vzug_api.get_zh_mode() == -1
+


### PR DESCRIPTION
Two independent gaps in `VZugApi._command`, both found while debugging #146.
Neither is model specific.

**1. `TransportError` never counted as an attempt.** The handler ended in
`continue`, which skips the `attempt_idx += 1` at the end of the loop body, so
`while attempt_idx < attempts` never terminates. Since the backoff is computed as
`attempt_idx * retry_delay`, there was no delay between retries either — visible
in my logs as retries one millisecond apart. An appliance that stays unreachable
would spin against the connection pool.

**2. A JSON error body passed the type assertion.** Appliances answer some
commands with `{"error":{"code":503.01}}` and HTTP 200. `isinstance(data, dict)`
is satisfied, so the error was stored as valid data and no retry was triggered.
For `getCommand` this lands in the config tree as a command without a `value`.

The error body now raises before the type check and goes through the existing
retry path and `value_on_err` fallback. `get_zh_mode` also uses
`data.get("value", -1)` so an unexpected body can't raise a `KeyError` outside
that path.

Four unit tests added.

Refs #146