### PR TITLE
fix: don't let an empty getCategories response clear all config entities

### DIFF
--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -266,6 +266,8 @@ class VZugApi:
         )
         self._client = httpx.AsyncClient(auth=auth, transport=transport)
         self._base_url = URL(base_url)
+        # set once we learn that this appliance really doesn't have any categories
+        self._categories_may_be_empty = False
 
     async def _command(
         self,
@@ -468,6 +470,18 @@ class VZugApi:
 
     async def aggregate_config(self) -> AggConfig:
         category_keys = await self.list_categories()
+        if not category_keys and not self._categories_may_be_empty:
+            # some appliances wrongly return an empty list when the hh module is
+            # busy, others (ex. AdoraWash V4000) really don't have any categories.
+            # Retry a couple of times, then believe the appliance and stop retrying.
+            for delay in (1.0, 2.0):
+                _LOGGER.debug("getCategories returned empty, retrying in %ss", delay)
+                await asyncio.sleep(delay)
+                category_keys = await self.list_categories()
+                if category_keys:
+                    break
+        self._categories_may_be_empty = not category_keys
+
         config_tree: AggConfig = {}
         for category_key in category_keys:
             category_raw, command_keys = await asyncio.gather(

--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from . import api
 from .const import DOMAIN
@@ -20,6 +20,12 @@ UPDATE_COORD_IDLE_INTERVAL = timedelta(hours=6)
 UPDATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=5)
 
 ConfigCoordinator = DataUpdateCoordinator[api.AggConfig]
+
+# how many consecutive bad updates we cover by keeping the previous data around.
+# the appliance answers '200 []' or fails outright when it's busy and that must not
+# reach the entities, but the grace period has to be bounded so a genuine change
+# (ex. the eco counters being reset) still gets through.
+CONFIG_MAX_STALE_UPDATES = 3
 
 
 class Shared:
@@ -72,6 +78,7 @@ class Shared:
         self.unique_id_prefix = ""
         self.device_info = DeviceInfo()
         self._first_refresh_done = False
+        self._config_stale_count = 0
 
     async def async_config_entry_first_refresh(self) -> None:
         async with detect_auth_failed():
@@ -133,8 +140,32 @@ class Shared:
         return data
 
     async def _fetch_config(self) -> api.AggConfig:
-        async with detect_auth_failed():
-            return await self.client.aggregate_config()
+        previous = self.config_coord.data
+        try:
+            async with detect_auth_failed():
+                config_tree = await self.client.aggregate_config()
+            if not config_tree and previous:
+                # the appliance answers '200 []' to 'getCategories' when it's busy.
+                # An empty result is only believable if the previous one was empty too.
+                raise UpdateFailed("getCategories returned empty")
+        except ConfigEntryAuthFailed:
+            raise
+        except Exception as exc:
+            # 'previous is None' means we never had a successful update, so there is
+            # nothing to keep and the caller should see the failure
+            if previous is None or self._config_stale_count >= CONFIG_MAX_STALE_UPDATES:
+                raise
+            self._config_stale_count += 1
+            _LOGGER.debug(
+                "config update failed (%s/%s), keeping previous data: %r",
+                self._config_stale_count,
+                CONFIG_MAX_STALE_UPDATES,
+                exc,
+            )
+            return previous
+
+        self._config_stale_count = 0
+        return config_tree
 
 
 @contextlib.asynccontextmanager

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
-from custom_components.vzug.api import VZugApi
+from custom_components.vzug.api import AggCategory, VZugApi
 
 def _json_response(payload):
     """Build a mock httpx response which returns 'payload' from .json()."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 
-from custom_components.vzug.api import VZugApi
+from custom_components.vzug.api import AggCategory, VZugApi
 
 
 @pytest.fixture
@@ -118,3 +118,46 @@ async def test_json_repair_with_real_broken_device_status():
 
         assert result is not None
         assert len(result) == 8
+
+@pytest.mark.asyncio
+async def test_aggregate_config_retries_empty_categories(vzug_api):
+    """An empty 'getCategories' is a glitch and has to be retried."""
+    with (
+        patch.object(vzug_api, "list_categories", new_callable=AsyncMock) as categories,
+        patch.object(vzug_api, "get_category", new_callable=AsyncMock) as category,
+        patch.object(vzug_api, "list_commands", new_callable=AsyncMock) as commands,
+        patch.object(vzug_api, "get_command", new_callable=AsyncMock) as command,
+        patch("custom_components.vzug.api.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        categories.side_effect = [[], ["settings"]]
+        category.return_value = {"description": "Einstellungen"}
+        commands.return_value = ["brightness"]
+        command.return_value = {"command": "brightness", "value": "50"}
+
+        config_tree = await vzug_api.aggregate_config()
+
+        assert categories.call_count == 2
+        assert config_tree["settings"] == AggCategory(
+            key="settings",
+            description="Einstellungen",
+            commands={"brightness": {"command": "brightness", "value": "50"}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_config_stops_retrying_without_categories(vzug_api):
+    """Appliances without categories (ex. AdoraWash V4000) must not retry forever."""
+    with (
+        patch.object(vzug_api, "list_categories", new_callable=AsyncMock) as categories,
+        patch("custom_components.vzug.api.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        categories.return_value = []
+
+        assert await vzug_api.aggregate_config() == {}
+        assert categories.call_count == 3
+
+        # the appliance told us three times, we believe it now
+        categories.reset_mock()
+        assert await vzug_api.aggregate_config() == {}
+        assert categories.call_count == 1
+


### PR DESCRIPTION
On an AdoraWash V6000, `getCategories` intermittently returns `[]` with HTTP 200.
The coordinator treats that as a successful update, `UserConfigEntity.vzug_command`
swallows the resulting `LookupError`, and every config entity drops to `unknown` —
not `unavailable`, with nothing in the log above debug. Five minutes later the next
poll succeeds and the values come back.

`reject_empty=False` in `list_categories` is deliberate and correct — some
appliances (ex. AdoraWash V4000) genuinely have no categories — so this can't be
fixed by flipping that flag. Two layers instead:

- `aggregate_config` retries an empty result twice and remembers appliances that
  really return nothing. A V4000 pays two extra requests once and never again.
- `Shared._fetch_config` keeps the previous config tree for up to three
  consecutive failed or empty updates instead of publishing an empty one. Config
  values are settings rather than measurements, so briefly serving the last known
  state is safe, and the bound makes a genuinely changed appliance converge.
  `ConfigEntryAuthFailed` still propagates, and the very first refresh still fails
  loudly so HA retries the setup with backoff.

The second layer also covers partial failures: `get_category`, `list_commands` and
`get_command` have no `value_on_err`, so a single failed command used to take down
the whole poll.

Two unit tests added.

Refs #146