### PR TITLE
feat: re-enable the getZHMode warm-up as a one-time capability probe

### DIFF
--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -16,6 +16,11 @@ from . import discovery  # noqa: F401 # type: ignore
 
 _LOGGER = logging.getLogger(__name__)
 
+# how many consecutive failures it takes before we accept that an appliance doesn't
+# know 'getZHMode'. These devices fail a request every now and then, so a single
+# error is not enough to write the command off.
+ZH_MODE_WARMUP_MAX_FAILURES = 3
+
 DeviceStatusInactiveT = Literal["true"] | Literal["false"]
 
 
@@ -266,8 +271,8 @@ class VZugApi:
         )
         self._client = httpx.AsyncClient(auth=auth, transport=transport)
         self._base_url = URL(base_url)
-        # unset once we learn that this appliance doesn't know 'getZHMode'
-        self._zh_mode_warmup = True
+        # consecutive warm-up failures, see ZH_MODE_WARMUP_MAX_FAILURES
+        self._zh_mode_warmup_failures = 0
         # set once we learn that this appliance really doesn't have any categories
         self._categories_may_be_empty = False
 
@@ -385,16 +390,24 @@ class VZugApi:
 
     async def aggregate_state(self, *, default_on_error: bool = True) -> AggState:
         zh_mode = -1
-        if self._zh_mode_warmup:
+        if self._zh_mode_warmup_failures < ZH_MODE_WARMUP_MAX_FAILURES:
             # a cheap 'hh' command before the state poll keeps 'getEcoInfo' from
             # returning zeroed data on some appliances (ex. AdoraWash V6000).
             # Appliances which don't know the command (ex. Adora SLQ) answer with an
-            # error, so we probe once and then stop asking.
+            # error - but so does a healthy one every now and then, so only give up
+            # after it has failed several times in a row.
             try:
                 zh_mode = await self.get_zh_mode(attempts=1)
             except Exception as exc:
-                _LOGGER.debug("zh_mode warm-up unsupported, disabling: %r", exc)
-                self._zh_mode_warmup = False
+                self._zh_mode_warmup_failures += 1
+                _LOGGER.debug(
+                    "zh_mode warm-up failed (%s/%s): %r",
+                    self._zh_mode_warmup_failures,
+                    ZH_MODE_WARMUP_MAX_FAILURES,
+                    exc,
+                )
+            else:
+                self._zh_mode_warmup_failures = 0
 
         async def _device() -> tuple[DeviceStatus, datetime]:
             data = await self.get_device_status(default_on_error=default_on_error)

--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -266,6 +266,8 @@ class VZugApi:
         )
         self._client = httpx.AsyncClient(auth=auth, transport=transport)
         self._base_url = URL(base_url)
+        # unset once we learn that this appliance doesn't know 'getZHMode'
+        self._zh_mode_warmup = True
 
     async def _command(
         self,
@@ -375,9 +377,17 @@ class VZugApi:
         raise last_exc
 
     async def aggregate_state(self, *, default_on_error: bool = True) -> AggState:
-        # always start with zh_mode, that seems to do something??
-        # zh_mode = await self.get_zh_mode(default_on_error=True)
         zh_mode = -1
+        if self._zh_mode_warmup:
+            # a cheap 'hh' command before the state poll keeps 'getEcoInfo' from
+            # returning zeroed data on some appliances (ex. AdoraWash V6000).
+            # Appliances which don't know the command (ex. Adora SLQ) answer with an
+            # error, so we probe once and then stop asking.
+            try:
+                zh_mode = await self.get_zh_mode(attempts=1)
+            except Exception as exc:
+                _LOGGER.debug("zh_mode warm-up unsupported, disabling: %r", exc)
+                self._zh_mode_warmup = False
 
         async def _device() -> tuple[DeviceStatus, datetime]:
             data = await self.get_device_status(default_on_error=default_on_error)
@@ -607,11 +617,14 @@ class VZugApi:
             value_on_err=(lambda: AiFwVersion()) if default_on_error else None,
         )
 
-    async def get_zh_mode(self, *, default_on_error: bool = False) -> int:
+    async def get_zh_mode(
+        self, *, default_on_error: bool = False, attempts: int = 5
+    ) -> int:
         data = await self._command(
             "hh",
             command="getZHMode",
             expected_type=dict,
+            attempts=attempts,
             value_on_err=(lambda: {"value": -1}) if default_on_error else None,
         )
         return data["value"]

--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -20,6 +20,7 @@ UPDATE_COORD_IDLE_INTERVAL = timedelta(hours=6)
 UPDATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=5)
 
 ConfigCoordinator = DataUpdateCoordinator[api.AggConfig]
+STATE_MAX_STALE_UPDATES = 3
 
 
 class Shared:
@@ -72,6 +73,7 @@ class Shared:
         self.unique_id_prefix = ""
         self.device_info = DeviceInfo()
         self._first_refresh_done = False
+        self._eco_stale_count = 0
 
     async def async_config_entry_first_refresh(self) -> None:
         async with detect_auth_failed():
@@ -116,9 +118,27 @@ class Shared:
 
     async def _fetch_state(self) -> api.AggState:
         async with detect_auth_failed():
-            return await self.client.aggregate_state(
+            state = await self.client.aggregate_state(
                 default_on_error=self._first_refresh_done
             )
+
+        # an all-zero 'getEcoInfo' response is mapped to an empty EcoInfo, which would
+        # put every eco sensor to 'unknown'. Keep the previous values for a while
+        # instead - but not forever, the counters can legitimately be reset to 0.
+        previous = self.state_coord.data
+        if not state.eco_info and previous is not None and previous.eco_info:
+            if self._eco_stale_count < STATE_MAX_STALE_UPDATES:
+                self._eco_stale_count += 1
+                _LOGGER.debug(
+                    "eco info is empty (%s/%s), keeping previous values",
+                    self._eco_stale_count,
+                    STATE_MAX_STALE_UPDATES,
+                )
+                state.eco_info = previous.eco_info
+        else:
+            self._eco_stale_count = 0
+
+        return state
 
     async def _fetch_update(self) -> api.AggUpdateStatus:
         async with detect_auth_failed():

--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -20,7 +20,6 @@ UPDATE_COORD_IDLE_INTERVAL = timedelta(hours=6)
 UPDATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=5)
 
 ConfigCoordinator = DataUpdateCoordinator[api.AggConfig]
-STATE_MAX_STALE_UPDATES = 3
 
 # how many consecutive bad updates we cover by keeping the previous data around.
 # the appliance answers '200 []' or fails outright when it's busy and that must not
@@ -79,7 +78,6 @@ class Shared:
         self.unique_id_prefix = ""
         self.device_info = DeviceInfo()
         self._first_refresh_done = False
-        self._eco_stale_count = 0
         self._config_stale_count = 0
 
     async def async_config_entry_first_refresh(self) -> None:
@@ -125,27 +123,9 @@ class Shared:
 
     async def _fetch_state(self) -> api.AggState:
         async with detect_auth_failed():
-            state = await self.client.aggregate_state(
+            return await self.client.aggregate_state(
                 default_on_error=self._first_refresh_done
             )
-
-        # an all-zero 'getEcoInfo' response is mapped to an empty EcoInfo, which would
-        # put every eco sensor to 'unknown'. Keep the previous values for a while
-        # instead - but not forever, the counters can legitimately be reset to 0.
-        previous = self.state_coord.data
-        if not state.eco_info and previous is not None and previous.eco_info:
-            if self._eco_stale_count < STATE_MAX_STALE_UPDATES:
-                self._eco_stale_count += 1
-                _LOGGER.debug(
-                    "eco info is empty (%s/%s), keeping previous values",
-                    self._eco_stale_count,
-                    STATE_MAX_STALE_UPDATES,
-                )
-                state.eco_info = previous.eco_info
-        else:
-            self._eco_stale_count = 0
-
-        return state
 
     async def _fetch_update(self) -> api.AggUpdateStatus:
         async with detect_auth_failed():

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -211,7 +211,8 @@ async def assert_aggregate_meta(vzug_client, expected_result):
 async def assert_aggregate_state( vzug_client, expected_result, expect_energy: bool):
     state = await vzug_client.aggregate_state()
 
-    assert state.zh_mode == -1
+    # appliances which don't know 'getZHMode' disable the warm-up and stay at -1
+    assert state.zh_mode == expected_result.hh_zh_mode
     assert state.device["Serial"] == expected_result.ai_device_status["Serial"]
     assert (datetime.now().astimezone() - state.device_fetched_at).total_seconds() <= 60
     if expect_energy:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,11 @@
 import httpx
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
-from custom_components.vzug.api import AggCategory, VZugApi
+from custom_components.vzug.api import (
+    ZH_MODE_WARMUP_MAX_FAILURES,
+    AggCategory,
+    VZugApi,
+)
 
 def _json_response(payload):
     """Build a mock httpx response which returns 'payload' from .json()."""
@@ -127,8 +131,8 @@ async def test_json_repair_with_real_broken_device_status():
         assert len(result) == 8
 
 @pytest.mark.asyncio
-async def test_zh_mode_warmup_disables_itself(vzug_api):
-    """Appliances which don't know 'getZHMode' get probed exactly once."""
+async def test_zh_mode_warmup_gives_up_after_repeated_failures(vzug_api):
+    """An appliance which doesn't know 'getZHMode' is written off eventually."""
     with (
         patch.object(vzug_api, "get_zh_mode", new_callable=AsyncMock) as zh_mode,
         patch.object(vzug_api, "get_device_status", new_callable=AsyncMock),
@@ -141,12 +145,39 @@ async def test_zh_mode_warmup_disables_itself(vzug_api):
         notifications.return_value = []
         eco_info.return_value = {}
 
-        state = await vzug_api.aggregate_state()
-        assert state.zh_mode == -1
-        assert vzug_api._zh_mode_warmup is False
+        for _ in range(ZH_MODE_WARMUP_MAX_FAILURES):
+            state = await vzug_api.aggregate_state()
+            assert state.zh_mode == -1
 
+        assert zh_mode.call_count == ZH_MODE_WARMUP_MAX_FAILURES
+
+        # the appliance has told us often enough, stop asking
         await vzug_api.aggregate_state()
-        assert zh_mode.call_count == 1
+        assert zh_mode.call_count == ZH_MODE_WARMUP_MAX_FAILURES
+
+
+@pytest.mark.asyncio
+async def test_zh_mode_warmup_survives_a_single_failure(vzug_api):
+    """These devices fail a request every now and then; that must not be fatal."""
+    with (
+        patch.object(vzug_api, "get_zh_mode", new_callable=AsyncMock) as zh_mode,
+        patch.object(vzug_api, "get_device_status", new_callable=AsyncMock),
+        patch.object(
+            vzug_api, "get_last_push_notifications", new_callable=AsyncMock
+        ) as notifications,
+        patch.object(vzug_api, "get_eco_info", new_callable=AsyncMock) as eco_info,
+    ):
+        zh_mode.side_effect = [httpx.ReadTimeout(""), 2, httpx.ReadTimeout(""), 2]
+        notifications.return_value = []
+        eco_info.return_value = {}
+
+        assert (await vzug_api.aggregate_state()).zh_mode == -1
+        assert (await vzug_api.aggregate_state()).zh_mode == 2
+
+        # the success reset the counter, so another blip is survivable too
+        assert (await vzug_api.aggregate_state()).zh_mode == -1
+        assert (await vzug_api.aggregate_state()).zh_mode == 2
+        assert zh_mode.call_count == 4
 
 
 @pytest.mark.asyncio
@@ -176,6 +207,9 @@ async def test_zh_mode_warmup_runs_before_the_state_poll(vzug_api):
 
         assert state.zh_mode == 2
         assert calls == ["getZHMode", "getEcoInfo"]
+
+
+@pytest.mark.asyncio
 async def test_aggregate_config_retries_empty_categories(vzug_api):
     """An empty 'getCategories' is a glitch and has to be retried."""
     with (
@@ -216,6 +250,9 @@ async def test_aggregate_config_stops_retrying_without_categories(vzug_api):
         categories.reset_mock()
         assert await vzug_api.aggregate_config() == {}
         assert categories.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_transport_error_counts_as_attempt(vzug_api):
     """A transport error must not restart the loop without incrementing the counter."""
     with patch.object(vzug_api._client, "get", new_callable=AsyncMock) as mock_get:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,3 +118,54 @@ async def test_json_repair_with_real_broken_device_status():
 
         assert result is not None
         assert len(result) == 8
+
+@pytest.mark.asyncio
+async def test_zh_mode_warmup_disables_itself(vzug_api):
+    """Appliances which don't know 'getZHMode' get probed exactly once."""
+    with (
+        patch.object(vzug_api, "get_zh_mode", new_callable=AsyncMock) as zh_mode,
+        patch.object(vzug_api, "get_device_status", new_callable=AsyncMock),
+        patch.object(
+            vzug_api, "get_last_push_notifications", new_callable=AsyncMock
+        ) as notifications,
+        patch.object(vzug_api, "get_eco_info", new_callable=AsyncMock) as eco_info,
+    ):
+        zh_mode.side_effect = ValueError("device returned an error response")
+        notifications.return_value = []
+        eco_info.return_value = {}
+
+        state = await vzug_api.aggregate_state()
+        assert state.zh_mode == -1
+        assert vzug_api._zh_mode_warmup is False
+
+        await vzug_api.aggregate_state()
+        assert zh_mode.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_zh_mode_warmup_runs_before_the_state_poll(vzug_api):
+    """The warm-up is only useful if it precedes the other commands."""
+    calls: list[str] = []
+
+    async def _zh_mode(**kwargs):
+        calls.append("getZHMode")
+        return 2
+
+    async def _eco_info(**kwargs):
+        calls.append("getEcoInfo")
+        return {"energy": {"total": 615.7}}
+
+    with (
+        patch.object(vzug_api, "get_zh_mode", side_effect=_zh_mode),
+        patch.object(vzug_api, "get_device_status", new_callable=AsyncMock),
+        patch.object(
+            vzug_api, "get_last_push_notifications", new_callable=AsyncMock
+        ) as notifications,
+        patch.object(vzug_api, "get_eco_info", side_effect=_eco_info),
+    ):
+        notifications.return_value = []
+
+        state = await vzug_api.aggregate_state()
+
+        assert state.zh_mode == 2
+        assert calls == ["getZHMode", "getEcoInfo"]


### PR DESCRIPTION
The `getZHMode` warm-up in `aggregate_state` was commented out in #106 (fixing
#75) because the Adora SLQ doesn't know the command and answers with an error,
which took down the whole state update.

On an AdoraWash V6000 the warm-up has a measurable effect. Without it, `getEcoInfo`
alternates between real values and all-zeros on roughly every other poll, and since
`get_eco_info` maps an all-zero response to an empty `EcoInfo`, all six eco sensors
go to `unknown` every other cycle. With the warm-up enabled, seven consecutive
polls returned real values and no zeros at all. But it would break the SQL again.

Rather than enabling it unconditionally, it is now a one-time capability probe:
one call with `attempts=1`, wrapped in try/except, permanently disabled for that
client as soon as the appliance answers with an error. A SLQ-type appliance pays
exactly one request per HA start; a V6000 gets the warm-up.

As a fallback for appliances where the warm-up doesn't help, `Shared._fetch_state`
keeps the previous eco values for up to three polls (90 s) when `getEcoInfo` comes
back empty. The bound matters because `ecomXstatXtotalXclear` can legitimately
reset the counters to zero. (<- This is an AI idea)

`assert_aggregate_state` now compares `zh_mode` against the fixture value instead
of a hardcoded `-1`; the fixtures already carry it (`2` for the V6000/Dish/Combair,
`-1` for SLQ/TSLQ).

I can only test one appliance (V6000), so I'd appreciate a sanity check on the probe
approach.

With these fixes, my V6000 constantly shows correct entities for 5 hours (while they broke after 5min before).

Refs #146, #75