### PR TITLE
fix: keep the previous eco values when getEcoInfo returns zeros

### DIFF
--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -26,6 +26,7 @@ ConfigCoordinator = DataUpdateCoordinator[api.AggConfig]
 # reach the entities, but the grace period has to be bounded so a genuine change
 # (ex. the eco counters being reset) still gets through.
 CONFIG_MAX_STALE_UPDATES = 3
+STATE_MAX_STALE_UPDATES = 3
 
 
 class Shared:
@@ -79,6 +80,7 @@ class Shared:
         self.device_info = DeviceInfo()
         self._first_refresh_done = False
         self._config_stale_count = 0
+        self._eco_stale_count = 0
 
     async def async_config_entry_first_refresh(self) -> None:
         async with detect_auth_failed():
@@ -123,9 +125,27 @@ class Shared:
 
     async def _fetch_state(self) -> api.AggState:
         async with detect_auth_failed():
-            return await self.client.aggregate_state(
+            state = await self.client.aggregate_state(
                 default_on_error=self._first_refresh_done
             )
+
+        # an all-zero 'getEcoInfo' response is mapped to an empty EcoInfo, which would
+        # put every eco sensor to 'unknown'. Keep the previous values for a while
+        # instead - but not forever, the counters can legitimately be reset to 0.
+        previous = self.state_coord.data
+        if not state.eco_info and previous is not None and previous.eco_info:
+            if self._eco_stale_count < STATE_MAX_STALE_UPDATES:
+                self._eco_stale_count += 1
+                _LOGGER.debug(
+                    "eco info is empty (%s/%s), keeping previous values",
+                    self._eco_stale_count,
+                    STATE_MAX_STALE_UPDATES,
+                )
+                state.eco_info = previous.eco_info
+        else:
+            self._eco_stale_count = 0
+
+        return state
 
     async def _fetch_update(self) -> api.AggUpdateStatus:
         async with detect_auth_failed():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vzug.api import AggState
+from custom_components.vzug.shared import STATE_MAX_STALE_UPDATES, Shared
+
+_ECO_INFO = {"water": {"total": 80085.5}, "energy": {"total": 615.7}}
+
+
+@pytest.fixture
+def shared():
+    """A Shared instance without the HomeAssistant machinery around it."""
+    instance = Shared.__new__(Shared)
+    instance.client = MagicMock()
+    instance.state_coord = MagicMock()
+    instance.state_coord.data = None
+    instance._first_refresh_done = True
+    instance._eco_stale_count = 0
+    return instance
+
+
+def _state(eco_info):
+    return AggState(
+        zh_mode=2,
+        device={"Inactive": "true"},
+        device_fetched_at=datetime(2026, 8, 11, 12, 0, tzinfo=UTC),
+        notifications=[],
+        eco_info=eco_info,
+    )
+
+
+async def _poll(shared: Shared, eco_info) -> AggState:
+    """Run one update and store the result the way the coordinator would."""
+    shared.client.aggregate_state = AsyncMock(return_value=_state(eco_info))
+    state = await shared._fetch_state()
+    shared.state_coord.data = state
+    return state
+
+
+@pytest.mark.asyncio
+async def test_zeroed_eco_info_keeps_the_previous_values(shared):
+    """An all-zero response would otherwise put every eco sensor to 'unknown'."""
+    await _poll(shared, _ECO_INFO)
+
+    state = await _poll(shared, {})
+
+    assert state.eco_info == _ECO_INFO
+
+
+@pytest.mark.asyncio
+async def test_a_real_response_resets_the_grace_period(shared):
+    await _poll(shared, _ECO_INFO)
+    await _poll(shared, {})
+    assert shared._eco_stale_count == 1
+
+    await _poll(shared, _ECO_INFO)
+
+    assert shared._eco_stale_count == 0
+
+
+@pytest.mark.asyncio
+async def test_the_grace_period_is_bounded(shared):
+    """'ecomXstatXtotalXclear' resets the counters, that has to reach the sensors."""
+    await _poll(shared, _ECO_INFO)
+
+    for _ in range(STATE_MAX_STALE_UPDATES):
+        assert (await _poll(shared, {})).eco_info == _ECO_INFO
+
+    assert (await _poll(shared, {})).eco_info == {}
+
+
+@pytest.mark.asyncio
+async def test_without_previous_values_there_is_nothing_to_keep(shared):
+    """The very first update has no history to fall back on."""
+    state = await _poll(shared, {})
+
+    assert state.eco_info == {}
+    assert shared._eco_stale_count == 0


### PR DESCRIPTION
Workaround for #41. `getEcoInfo` intermittently returns all zeros; `get_eco_info` maps that to an empty `EcoInfo`, so every eco sensor drops to `unknown` and the Energy Dashboard gets a gap. Reported for an AdoraWash V4000 in #41 and confirmed
by a second user there.

The previous values are kept for up to three consecutive updates instead. The bound is deliberate: `ecomXstatXtotalXclear` can legitimately reset the counters to zero, and that has to reach the entities, 90 seconds later at the default interval.

Same shape as the config-side grace period from #148, so the two read alike.

This is independent of #149. The `getZHMode` warm-up there prevents the zeros on my AdoraWash V6000 (all clean polls with it, zeros on roughly every other poll without), but #41 is reported on a V4000 where that doesn't apply. so this is for the appliances #149 can't help.