### PR TITLE
refactor: refresh the config tree on demand instead of every 5 minutes

### DIFF
--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -20,6 +20,11 @@ UPDATE_COORD_IDLE_INTERVAL = timedelta(hours=6)
 UPDATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=5)
 
 ConfigCoordinator = DataUpdateCoordinator[api.AggConfig]
+# the config tree is a snapshot of the appliance's settings, so it barely ever
+# changes on its own. Polling it every few minutes only widens the window for the
+# transient failures this API is prone to, so it is refreshed on demand instead:
+# whenever the appliance starts or finishes a program, and after every write.
+CONFIG_COORD_INTERVAL = timedelta(hours=1)
 
 # how many consecutive bad updates we cover by keeping the previous data around.
 # the appliance answers '200 []' or fails outright when it's busy and that must not
@@ -71,7 +76,7 @@ class Shared:
             hass,
             _LOGGER,
             name="config",
-            update_interval=timedelta(minutes=5),
+            update_interval=CONFIG_COORD_INTERVAL,
             update_method=self._fetch_config,
         )
 
@@ -81,6 +86,7 @@ class Shared:
         self._first_refresh_done = False
         self._config_stale_count = 0
         self._eco_stale_count = 0
+        self._device_active: bool | None = None
 
     async def async_config_entry_first_refresh(self) -> None:
         async with detect_auth_failed():
@@ -145,7 +151,24 @@ class Shared:
         else:
             self._eco_stale_count = 0
 
+        self._track_activity(state.device)
         return state
+
+    def _track_activity(self, device: api.DeviceStatus) -> None:
+        """Refresh the config tree whenever the appliance starts or finishes."""
+        inactive = device.get("Inactive")
+        if inactive not in ("true", "false"):
+            # unknown state, don't guess
+            return
+
+        active = inactive == "false"
+        if self._device_active is not None and active != self._device_active:
+            # the eco statistics in the config tree ('ecomXstatXtotal' and friends)
+            # are updated when a program completes, and someone standing at the
+            # appliance may have changed settings on its panel
+            _LOGGER.debug("device activity changed to %s, refreshing config", active)
+            self.hass.async_create_task(self.config_coord.async_request_refresh())
+        self._device_active = active
 
     async def _fetch_update(self) -> api.AggUpdateStatus:
         async with detect_auth_failed():

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -13,12 +13,19 @@ _ECO_INFO = {"water": {"total": 80085.5}, "energy": {"total": 615.7}}
 def shared():
     """A Shared instance without the HomeAssistant machinery around it."""
     instance = Shared.__new__(Shared)
+    instance.hass = MagicMock()
     instance.client = MagicMock()
+    instance.config_coord = MagicMock()
     instance.state_coord = MagicMock()
     instance.state_coord.data = None
     instance._first_refresh_done = True
     instance._eco_stale_count = 0
+    instance._device_active = None
     return instance
+
+
+def _config_refreshes(shared: Shared) -> int:
+    return shared.hass.async_create_task.call_count
 
 
 def _state(eco_info):
@@ -78,3 +85,48 @@ async def test_without_previous_values_there_is_nothing_to_keep(shared):
 
     assert state.eco_info == {}
     assert shared._eco_stale_count == 0
+
+
+def test_first_state_does_not_refresh_config(shared):
+    """Nothing to compare against yet, so there is nothing to react to."""
+    shared._track_activity({"Inactive": "true"})
+
+    assert shared._device_active is False
+    assert _config_refreshes(shared) == 0
+
+
+def test_program_start_refreshes_config(shared):
+    shared._track_activity({"Inactive": "true"})
+    shared._track_activity({"Inactive": "false"})
+
+    assert shared._device_active is True
+    assert _config_refreshes(shared) == 1
+
+
+def test_program_end_refreshes_config(shared):
+    """The eco statistics in the config tree are updated on completion."""
+    shared._track_activity({"Inactive": "false"})
+    shared._track_activity({"Inactive": "true"})
+
+    assert _config_refreshes(shared) == 1
+
+
+def test_unchanged_activity_does_not_refresh_config(shared):
+    for _ in range(5):
+        shared._track_activity({"Inactive": "true"})
+
+    assert _config_refreshes(shared) == 0
+
+
+def test_unknown_activity_is_ignored(shared):
+    """An appliance which doesn't report 'Inactive' must not trigger anything."""
+    shared._track_activity({"Inactive": "false"})
+    shared._track_activity({})
+    shared._track_activity({"Inactive": "maybe"})
+
+    # the last known state is kept, so a later 'true' still counts as a change
+    assert shared._device_active is True
+    assert _config_refreshes(shared) == 0
+
+    shared._track_activity({"Inactive": "true"})
+    assert _config_refreshes(shared) == 1


### PR DESCRIPTION
This one is kinda a leftover from #146 but also related to #51. I will add 2 more PRs toward #51. This one addresses the 146-side of it.

The config tree is a snapshot of the appliance's settings and barely ever changes on its own, but it is polled every 5 minutes at ~25 requests per poll. On my AdoraWash V6000 that API answers `200 []` to `getCategories` in about a third of the polls and throws sporadic 400s on valid parameters (#146), so the polling frequency is itself a significant source of the transient failures.

It is now refreshed hourly plus on demand:
- after every write, which the writing platforms already trigger themselves
- whenever the appliance starts or finishes a program

The second one matters twice over. The eco statistics (`ecomXstatXtotal` and friends) are part of the config tree and are updated on completion. And someone who changes a setting on the appliance's panel usually starts a program right after, so the change is picked up within seconds rather than at the next interval.

What is left for the hourly fallback is "changed something at the appliance and walked away without starting it". That is the one case which now takes up to an hour instead of 5 minutes.

Appliances which don't report `Inactive` keep the hourly interval and are never guessed about.

2 more PRs incoming after this one is merged:
- reduced polling to let the appliance sleep much longer
- add a button to "refresh now", because after above changes an entities refresh will not update values if the appliance sleeps. automations can use that to _really_ refresh.