### PR TITLE
feat: let the appliance sleep while it is in standby

### DIFF
--- a/custom_components/vzug/api/__init__.py
+++ b/custom_components/vzug/api/__init__.py
@@ -388,9 +388,24 @@ class VZugApi:
 
         raise last_exc
 
-    async def aggregate_state(self, *, default_on_error: bool = True) -> AggState:
+    async def aggregate_state(
+        self,
+        *,
+        default_on_error: bool = True,
+        include_device: bool = True,
+        include_eco: bool = True,
+    ) -> AggState:
+        """Fetch the appliance state.
+
+        'getDeviceStatus' wakes the appliance up, 'getLastPUSHNotifications' is
+        answered by the AI module without touching it. Skipping the former lets the
+        caller keep an eye on the appliance without disturbing it; the skipped
+        values come back empty and are the caller's to carry over.
+        """
         zh_mode = -1
-        if self._zh_mode_warmup_failures < ZH_MODE_WARMUP_MAX_FAILURES:
+        # the warm-up only exists to keep 'getEcoInfo' from returning zeros, so
+        # there is no point in paying for it when we don't ask for eco info
+        if include_eco and self._zh_mode_warmup_failures < ZH_MODE_WARMUP_MAX_FAILURES:
             # a cheap 'hh' command before the state poll keeps 'getEcoInfo' from
             # returning zeroed data on some appliances (ex. AdoraWash V6000).
             # Appliances which don't know the command (ex. Adora SLQ) answer with an
@@ -410,13 +425,20 @@ class VZugApi:
                 self._zh_mode_warmup_failures = 0
 
         async def _device() -> tuple[DeviceStatus, datetime]:
+            if not include_device:
+                return DeviceStatus(), datetime.now(UTC)
             data = await self.get_device_status(default_on_error=default_on_error)
             return data, datetime.now(UTC)
+
+        async def _eco() -> EcoInfo:
+            if not include_eco:
+                return EcoInfo()
+            return await self.get_eco_info(default_on_error=default_on_error)
 
         (device, device_fetched_at), notifications, eco_info = await asyncio.gather(
             _device(),
             self.get_last_push_notifications(default_on_error=default_on_error),
-            self.get_eco_info(default_on_error=default_on_error),
+            _eco(),
         )
 
         return AggState(

--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import yarl
 from homeassistant.core import HomeAssistant
@@ -15,6 +15,15 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 StateCoordinator = DataUpdateCoordinator[api.AggState]
+# 'getDeviceStatus' wakes the appliance and it stays awake for ~20s afterwards, so
+# polling it every 30s keeps the appliance awake around the clock. While a program
+# runs it is awake anyway and polling is free; in standby we only ask the AI module
+# for notifications, which doesn't disturb the appliance at all, and pay for a real
+# status probe every few minutes to catch a program someone started by hand.
+STATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=30)
+STATE_COORD_IDLE_INTERVAL = timedelta(seconds=60)
+STATE_COORD_IDLE_PROBE_INTERVAL = timedelta(minutes=5)
+
 UpdateCoordinator = DataUpdateCoordinator[api.AggUpdateStatus]
 UPDATE_COORD_IDLE_INTERVAL = timedelta(hours=6)
 UPDATE_COORD_ACTIVE_INTERVAL = timedelta(seconds=5)
@@ -62,7 +71,7 @@ class Shared:
             hass,
             _LOGGER,
             name="state",
-            update_interval=timedelta(seconds=30),
+            update_interval=STATE_COORD_ACTIVE_INTERVAL,
             update_method=self._fetch_state,
         )
         self.update_coord = DataUpdateCoordinator(
@@ -87,6 +96,8 @@ class Shared:
         self._config_stale_count = 0
         self._eco_stale_count = 0
         self._device_active: bool | None = None
+        self._last_device_probe: datetime | None = None
+        self._last_notification: str | None = None
 
     async def async_config_entry_first_refresh(self) -> None:
         async with detect_auth_failed():
@@ -130,15 +141,34 @@ class Shared:
         self._first_refresh_done = True
 
     async def _fetch_state(self) -> api.AggState:
+        previous = self.state_coord.data
+        probe = self._device_probe_due()
+
         async with detect_auth_failed():
             state = await self.client.aggregate_state(
-                default_on_error=self._first_refresh_done
+                default_on_error=self._first_refresh_done,
+                include_device=probe,
+                include_eco=probe,
             )
+
+            if self._note_notifications(state.notifications) and not probe:
+                # something happened at the appliance: a program finished, or a
+                # timed one started. It is awake now anyway, so this costs nothing.
+                _LOGGER.debug("new notification, fetching the full state")
+                probe = True
+                state = await self.client.aggregate_state(
+                    default_on_error=self._first_refresh_done
+                )
+                self.hass.async_create_task(self.config_coord.async_request_refresh())
+
+        if not probe:
+            return self._carry_over(state, previous)
+
+        self._last_device_probe = datetime.now(UTC)
 
         # an all-zero 'getEcoInfo' response is mapped to an empty EcoInfo, which would
         # put every eco sensor to 'unknown'. Keep the previous values for a while
         # instead - but not forever, the counters can legitimately be reset to 0.
-        previous = self.state_coord.data
         if not state.eco_info and previous is not None and previous.eco_info:
             if self._eco_stale_count < STATE_MAX_STALE_UPDATES:
                 self._eco_stale_count += 1
@@ -152,6 +182,47 @@ class Shared:
             self._eco_stale_count = 0
 
         self._track_activity(state.device)
+        self.state_coord.update_interval = (
+            STATE_COORD_IDLE_INTERVAL
+            if self._device_active is False
+            else STATE_COORD_ACTIVE_INTERVAL
+        )
+        return state
+
+    def _device_probe_due(self) -> bool:
+        """Whether this poll may wake the appliance up."""
+        if self._device_active is not False:
+            # running, or we don't know yet - either way it isn't asleep
+            return True
+        if self._last_device_probe is None:
+            return True
+        age = datetime.now(UTC) - self._last_device_probe
+        return age >= STATE_COORD_IDLE_PROBE_INTERVAL
+
+    def _note_notifications(self, notifications: list[api.PushNotification]) -> bool:
+        """Remember the most recent notification, reporting whether it is new."""
+        try:
+            latest = notifications[0]["date"]
+        except LookupError:
+            return False
+
+        previous, self._last_notification = self._last_notification, latest
+        return previous is not None and previous != latest
+
+    def _carry_over(
+        self, state: api.AggState, previous: api.AggState | None
+    ) -> api.AggState:
+        """Fill in the values we deliberately didn't ask for."""
+        if previous is None:
+            return state
+
+        # 'device_fetched_at' has to travel with the device data: ProgramEnd computes
+        # the finishing time as 'device_fetched_at + remaining', so a fresh timestamp
+        # on stale data would push the countdown further out on every poll
+        state.device = previous.device
+        state.device_fetched_at = previous.device_fetched_at
+        state.eco_info = previous.eco_info
+        state.zh_mode = previous.zh_mode
         return state
 
     def _track_activity(self, device: api.DeviceStatus) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -311,3 +311,30 @@ async def test_get_zh_mode_survives_missing_value_key(vzug_api):
 
         assert await vzug_api.get_zh_mode() == -1
 
+
+@pytest.mark.asyncio
+async def test_aggregate_state_can_skip_the_appliance(vzug_api):
+    """'getDeviceStatus' wakes the appliance, so it has to be skippable."""
+    with (
+        patch.object(vzug_api, "get_zh_mode", new_callable=AsyncMock) as zh_mode,
+        patch.object(vzug_api, "get_device_status", new_callable=AsyncMock) as device,
+        patch.object(
+            vzug_api, "get_last_push_notifications", new_callable=AsyncMock
+        ) as notifications,
+        patch.object(vzug_api, "get_eco_info", new_callable=AsyncMock) as eco_info,
+    ):
+        notifications.return_value = [{"date": "2026-08-09T15:14:46Z"}]
+
+        state = await vzug_api.aggregate_state(include_device=False, include_eco=False)
+
+        # the only command that ran is the one served by the AI module
+        notifications.assert_awaited_once()
+        device.assert_not_awaited()
+        eco_info.assert_not_awaited()
+        # the warm-up only exists for getEcoInfo, so it must not run either
+        zh_mode.assert_not_awaited()
+
+        assert state.device == {}
+        assert state.eco_info == {}
+        assert state.notifications == [{"date": "2026-08-09T15:14:46Z"}]
+

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -4,7 +4,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.vzug.api import AggState
-from custom_components.vzug.shared import STATE_MAX_STALE_UPDATES, Shared
+from custom_components.vzug.shared import (
+    STATE_COORD_ACTIVE_INTERVAL,
+    STATE_COORD_IDLE_INTERVAL,
+    STATE_COORD_IDLE_PROBE_INTERVAL,
+    STATE_MAX_STALE_UPDATES,
+    Shared,
+)
 
 _ECO_INFO = {"water": {"total": 80085.5}, "energy": {"total": 615.7}}
 
@@ -21,6 +27,8 @@ def shared():
     instance._first_refresh_done = True
     instance._eco_stale_count = 0
     instance._device_active = None
+    instance._last_device_probe = None
+    instance._last_notification = None
     return instance
 
 
@@ -41,6 +49,9 @@ def _state(eco_info):
 async def _poll(shared: Shared, eco_info) -> AggState:
     """Run one update and store the result the way the coordinator would."""
     shared.client.aggregate_state = AsyncMock(return_value=_state(eco_info))
+    # eco info is only fetched on a poll that is allowed to wake the appliance, so
+    # force one - otherwise these tests would pass without reaching the code at all
+    shared._last_device_probe = None
     state = await shared._fetch_state()
     shared.state_coord.data = state
     return state
@@ -130,3 +141,123 @@ def test_unknown_activity_is_ignored(shared):
 
     shared._track_activity({"Inactive": "true"})
     assert _config_refreshes(shared) == 1
+
+
+_NOTIFICATION = "2026-08-09T15:14:46Z"
+
+
+def _full_state(*, inactive: str = "true", notification: str = _NOTIFICATION):
+    """What aggregate_state returns for a poll that asked for everything."""
+    return AggState(
+        zh_mode=2,
+        device={"Inactive": inactive, "Program": ""},
+        device_fetched_at=datetime(2026, 8, 9, 15, 0, tzinfo=UTC),
+        notifications=[{"date": notification, "message": "Programm beendet"}],
+        eco_info=_ECO_INFO,
+    )
+
+
+def _light_state(notification: str = _NOTIFICATION):
+    """What it returns when the device fetch was skipped."""
+    return AggState(
+        zh_mode=-1,
+        device={},
+        device_fetched_at=datetime.now(UTC),
+        notifications=[{"date": notification, "message": "Programm beendet"}],
+        eco_info={},
+    )
+
+
+def _in_standby(shared: Shared) -> None:
+    shared.state_coord.data = _full_state()
+    shared._device_active = False
+    shared._last_device_probe = datetime.now(UTC)
+    shared._last_notification = _NOTIFICATION
+
+
+@pytest.mark.asyncio
+async def test_first_poll_asks_for_everything(shared):
+    """We don't know the appliance's state yet, so we must not skip anything."""
+    shared.client.aggregate_state = AsyncMock(return_value=_full_state())
+
+    await shared._fetch_state()
+
+    kwargs = shared.client.aggregate_state.call_args.kwargs
+    assert kwargs["include_device"] is True
+    assert kwargs["include_eco"] is True
+    assert shared.state_coord.update_interval == STATE_COORD_IDLE_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_standby_poll_leaves_the_appliance_alone(shared):
+    """In standby only the AI module is asked, which doesn't wake the appliance."""
+    _in_standby(shared)
+    previous = shared.state_coord.data
+    shared.client.aggregate_state = AsyncMock(return_value=_light_state())
+
+    state = await shared._fetch_state()
+
+    kwargs = shared.client.aggregate_state.call_args.kwargs
+    assert kwargs["include_device"] is False
+    assert kwargs["include_eco"] is False
+
+    # the skipped values are carried over, timestamp included - a fresh one would
+    # push the ProgramEnd countdown further out on every poll
+    assert state.device == previous.device
+    assert state.device_fetched_at == previous.device_fetched_at
+    assert state.eco_info == previous.eco_info
+    # a deliberately skipped fetch is not a failure and must not burn the grace period
+    assert shared._eco_stale_count == 0
+
+
+@pytest.mark.asyncio
+async def test_standby_probes_the_device_after_the_interval(shared):
+    _in_standby(shared)
+    shared._last_device_probe = datetime.now(UTC) - STATE_COORD_IDLE_PROBE_INTERVAL
+    shared.client.aggregate_state = AsyncMock(return_value=_full_state())
+
+    await shared._fetch_state()
+
+    assert shared.client.aggregate_state.call_args.kwargs["include_device"] is True
+
+
+@pytest.mark.asyncio
+async def test_running_program_is_polled_in_full(shared):
+    """While a program runs the appliance is awake anyway, so polling is free."""
+    _in_standby(shared)
+    shared._device_active = True
+    shared.client.aggregate_state = AsyncMock(
+        return_value=_full_state(inactive="false")
+    )
+
+    await shared._fetch_state()
+
+    assert shared.client.aggregate_state.call_args.kwargs["include_device"] is True
+    assert shared.state_coord.update_interval == STATE_COORD_ACTIVE_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_new_notification_triggers_a_full_poll(shared):
+    """A program finished or a timed one started - fetch everything right away."""
+    _in_standby(shared)
+    shared._last_notification = "2026-08-09T09:06:42Z"
+    shared.client.aggregate_state = AsyncMock(
+        side_effect=[_light_state(), _full_state(inactive="false")]
+    )
+
+    state = await shared._fetch_state()
+
+    assert shared.client.aggregate_state.call_count == 2
+    assert "include_device" not in shared.client.aggregate_state.call_args.kwargs
+    assert state.device == {"Inactive": "false", "Program": ""}
+    assert _config_refreshes(shared) >= 1
+
+
+@pytest.mark.asyncio
+async def test_unchanged_notification_does_not_trigger_a_poll(shared):
+    _in_standby(shared)
+    shared.client.aggregate_state = AsyncMock(return_value=_light_state())
+
+    await shared._fetch_state()
+
+    assert shared.client.aggregate_state.call_count == 1


### PR DESCRIPTION
Addresses #51.

Measured on an AdoraWash V6000, WiFi LED as the indicator:

| | |
|---|---|
| integration off, app closed | dark, the appliance sleeps |
| V-ZUG app open | wake cycle of ~22s, repeating every 30s |
| integration running | the same |
| single `getLastPUSHNotifications` | **no** reaction at all, list still up to date|
| single `getDeviceStatus` from sleep | starts the ~22s cycle, answers `{"error":{"code":503.01}}` |
| the same call during the cycle | returns proper data |
| while a program runs | permanently lit, the appliance is awake anyway |

So `getDeviceStatus` is itself the wake-up call, and polling it every 30s keeps the appliance awake roughly 15 hours a day. The integration currently behaves like a permanently open V-ZUG app - which is fine for the app, because nobody leaves it
open for a day.

In standby the state update now only polls `getLastPUSHNotifications` every 60s, which doesn't wake up the appliance. A real status probe runs every 5 minutes, and any new notification triggers an immediate full poll. Both program completions and timed starts are announced by push, so those are picked up right away. Values that were not requested are carried over unchanged, device_fetched_at` included, because `ProgramEnd` computes its timestamp from it.

The trade-off: a program started by hand shows up up to 5 minutes late. Whoever is standing at the appliance knows earlier anyway, and the case where nobody is there is the timed start, which does send a notification. Wake time drops from ~15 h/day to
~1.8 h/day.

Note this touches the four eco tests from #150: their `_poll()` now forces a device probe, because otherwise they would take the standby shortcut and stop exercising the code they were written for.

I can only test an AdoraWash V6000. Appliances that don't report `Inactive` keep the previous behaviour, but I have no way to check whether other models wake the same way.

> For _me_ this is a good solution. I've had it running locally for ~2 days and it feels "smooth". But I know that this introduces a different behavior based on (my) real world use cases and that this might not be a generally valid approach. I can offer to add a OptionsFlow with a "reduced polling on/off switch" and/or a configurable probe interval for those who like it.  (Just a configurable interval might be clever because you can reach the old behavior by setting 30s and many more cases by setting other values. and it's much less complex than a on/off switch I guess.) Anyway, I'd need to think it through and most likely need some decisions from you because that would be the first OptionsFlow of this integration.

I'll add one more PR for a new button to force refresh entities, to be used by automations.