### PR TITLE
feat: add a button to poll the appliance right now

### DIFF
--- a/custom_components/vzug/button.py
+++ b/custom_components/vzug/button.py
@@ -16,7 +16,7 @@ async def async_setup_entry(
 ) -> None:
     shared: Shared = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[ButtonEntity] = []
+    entities: list[ButtonEntity] = [RefreshNow(shared)]
     if shared.meta.supports_update_status():
         entities.append(CheckUpdate(shared))
 
@@ -32,6 +32,31 @@ async def async_setup_entry(
                 )
 
     async_add_entities(entities)
+
+
+class RefreshNow(ButtonEntity):
+    """Bring every value up to date right now, waking the appliance if necessary.
+
+    While the appliance is in standby the state updates only talk to the AI module
+    so it can stay asleep, and the config tree is only read hourly. Both are a
+    deliberate trade-off, and this is the way out of it: for someone who just
+    changed a setting on the appliance's panel, or for an automation that knows
+    better than the integration does - a smart plug reporting power draw, a door
+    contact, a motion sensor in the laundry room.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_translation_key = "refresh_now"
+
+    def __init__(self, shared: Shared) -> None:
+        self.shared = shared
+
+        self._attr_unique_id = f"{shared.unique_id_prefix}-refresh-now"
+        self._attr_device_info = shared.device_info
+
+    async def async_press(self) -> None:
+        await self.shared.async_probe_device()
 
 
 class CheckUpdate(ButtonEntity):

--- a/custom_components/vzug/shared.py
+++ b/custom_components/vzug/shared.py
@@ -189,6 +189,20 @@ class Shared:
         )
         return state
 
+    async def async_probe_device(self) -> None:
+        """Bring everything up to date, waking the appliance if necessary.
+
+        In standby the state updates deliberately leave the appliance alone and the
+        config tree is only refreshed hourly, so neither a plain refresh nor waiting
+        gets fresh data. This is the way to ask for it anyway. Both coordinators are
+        included because the appliance is being woken either way, and a settings
+        change made on its panel is exactly the kind of thing someone would press
+        this for.
+        """
+        self._last_device_probe = None
+        await self.state_coord.async_request_refresh()
+        await self.config_coord.async_request_refresh()
+
     def _device_probe_due(self) -> bool:
         """Whether this poll may wake the appliance up."""
         if self._device_active is not False:

--- a/custom_components/vzug/translations/de.json
+++ b/custom_components/vzug/translations/de.json
@@ -43,6 +43,9 @@
     "button": {
       "check_update": {
         "name": "Nach Updates Suchen"
+      },
+      "refresh_now": {
+        "name": "Jetzt Aktualisieren"
       }
     },
     "sensor": {

--- a/custom_components/vzug/translations/en.json
+++ b/custom_components/vzug/translations/en.json
@@ -43,6 +43,9 @@
         "button": {
             "check_update": {
                 "name": "Check for Updates"
+            },
+            "refresh_now": {
+                "name": "Refresh Now"
             }
         },
         "sensor": {

--- a/custom_components/vzug/translations/fr.json
+++ b/custom_components/vzug/translations/fr.json
@@ -43,6 +43,9 @@
         "button": {
             "check_update": {
                 "name": "Vérifier les Mises à Jour"
+            },
+            "refresh_now": {
+                "name": "Actualiser Maintenant"
             }
         },
         "sensor": {

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -254,6 +254,28 @@ async def test_new_notification_triggers_a_full_poll(shared):
 
 
 @pytest.mark.asyncio
+async def test_probe_request_reaches_the_appliance(shared):
+    """A refresh asked for by hand must not be answered from standby shortcuts."""
+    _in_standby(shared)
+    shared.state_coord.async_request_refresh = AsyncMock()
+    shared.config_coord.async_request_refresh = AsyncMock()
+
+    await shared.async_probe_device()
+
+    # the settings are hourly otherwise, and changing one on the appliance's panel
+    # is exactly what someone would press this for
+    shared.config_coord.async_request_refresh.assert_awaited_once()
+
+    shared.state_coord.async_request_refresh.assert_awaited_once()
+    assert shared._device_probe_due() is True
+
+    # and the update it triggers really does ask for everything
+    shared.client.aggregate_state = AsyncMock(return_value=_full_state())
+    await shared._fetch_state()
+    assert shared.client.aggregate_state.call_args.kwargs["include_device"] is True
+
+
+@pytest.mark.asyncio
 async def test_unchanged_notification_does_not_trigger_a_poll(shared):
     _in_standby(shared)
     shared.client.aggregate_state = AsyncMock(return_value=_light_state())


### PR DESCRIPTION
Follow-up to #152, and deliberately separate so you can take the polling change without this one.

#151 and #152 made two trade-offs on purpose: in standby the appliance is left alone, so device data can be a few minutes old, and the config tree is only read every hourl. Both are right as defaults, but they leave no way to say "I know better, look now". A plain refresh takes the same standby shortcut, and waiting an hour for a setting you just changed on the appliance's panel isn't useful.

This button clears the probe timer and refreshes both coordinators. The appliance is being woken by getDeviceStatus anyway, so the config poll is essentially free at that moment: ~3s inside that 20s wake window.

It also gives automations a handle: Anything that knows more than the integration does can press it, maybe a smart plug reporting ower draw, a door contact, a motion sensor in the laundry room. which gets you instant detection without polling the appliance in between.

Note: this adds an entity to every device, unconditionally, unlike the existing `CheckUpdate` button. If you'd rather not have that, the polling changes work fine without it. No problem for me if you drop this.

<img width="627" height="280" alt="image" src="https://github.com/user-attachments/assets/57980cf3-4892-4e0b-a8ae-a2d9037913a9" />